### PR TITLE
Испавил ошибку в определении полной ортогональной системы (9.7)

### DIFF
--- a/course-2/mathematical-analysis/colloquiums/colloquium-3-questions/question-09.tex
+++ b/course-2/mathematical-analysis/colloquiums/colloquium-3-questions/question-09.tex
@@ -77,7 +77,7 @@
 \subsubsection{Полная ортогональная система (определение).}
 \begin{definition*}
     Ортогональная система $\left\{ l_n \right\}$ называется \textbf{полной} в пространстве $\mathcal{R}_2$, если $\forall f \in \mathcal{R}_2$
-    \[\forall \varepsilon > 0 \exists \left\{ a_n \right\}, N \in \NN \subset \CC: \| f - \sum_{n=1}^N a_n l_n \| < \varepsilon\]        
+    \[\forall \varepsilon > 0\ \exists \left\{ a_n \right\}\subset \CC, N \in \NN: \| f - \sum_{n=1}^N a_n l_n \| < \varepsilon\]
 \end{definition*}
 
 \subsubsection{Критерии полноты ортогональной системы (представимость любого элемента его рядом Фурье; равенство Парсеваля; отсутствие ненулевого элемента, ортогонального всем элементам системы).}


### PR DESCRIPTION
Было
![Screenshot from 2021-03-26 21-49-21](https://user-images.githubusercontent.com/26490401/112679409-33708380-8e7d-11eb-981d-ca617db92492.png)

Надо
![Screenshot from 2021-03-26 21-50-34](https://user-images.githubusercontent.com/26490401/112679557-5bf87d80-8e7d-11eb-8f50-cd5828017661.png)

Стало:
![Screenshot from 2021-03-26 21-52-36](https://user-images.githubusercontent.com/26490401/112679761-9bbf6500-8e7d-11eb-9db2-452f3805dbfc.png)
